### PR TITLE
Removendo padding duplicado nas linhas 17 e 24

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,6 @@ body{
 .sidebar__navigation{
     background-color: #121212;
     border-radius:8px;
-    padding:16px 0 0 16px;
 }
 
 .logo{


### PR DESCRIPTION
Revi a aula e parece aparentemente não estava com o espaçamento errado (mesmo com as linhas duplicadas. Mas localmente apresentou um grande recuo indesejado. Além disso, no arquivo final disponível no alura-cursos/spotify-imersao, essas informações de padding estão apenas no seletor .logo.